### PR TITLE
Addressed the PR 14 comments

### DIFF
--- a/oneandone/resource_oneandone_private_network_test.go
+++ b/oneandone/resource_oneandone_private_network_test.go
@@ -14,8 +14,8 @@ import (
 func TestAccOneandonePrivateNetwork_Basic(t *testing.T) {
 	var net oneandone.PrivateNetwork
 
-	name := "test2"
-	name_updated := "test2"
+	name := "test"
+	name_updated := "test1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/vendor/github.com/1and1/oneandone-cloudserver-sdk-go/sshkeys.go
+++ b/vendor/github.com/1and1/oneandone-cloudserver-sdk-go/sshkeys.go
@@ -65,16 +65,14 @@ func (api *API) CreateSSHKey(request *SSHKeyRequest) (string, *SSHKey, error) {
 	return result.Id, result, nil
 }
 
-func (api *API) DeleteSSHKey(id string) ([]SSHKey, error) {
-	result := []SSHKey{}
+func (api *API) DeleteSSHKey(id string) (*SSHKey, error) {
+	result := new(SSHKey)
 	url := createUrl(api, sshkeyPathSegment, id)
 	err := api.Client.Delete(url, nil, &result, http.StatusOK)
 	if err != nil {
 		return nil, err
 	}
-	for index := range result {
-		result[index].api = api
-	}
+	result.api = api
 	return result, nil
 }
 

--- a/website/docs/r/block_storage.html.markdown
+++ b/website/docs/r/block_storage.html.markdown
@@ -25,8 +25,8 @@ resource "oneandone_block_storage" "storage" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the storage
-* `size` - (Required) Size of the block storage (`min: 20, max: 500, multipleOf: 10`)
 * `datacenter` - (Optional) Location of desired 1and1 datacenter, where the block storage will be created. Can be `DE`, `GB`, `US` or `ES`
 * `description` - (Optional) Description for the block storage
+* `name` - (Required) The name of the storage
 * `server_id` - (Optional) ID of the server that the block storage will be attached to
+* `size` - (Required) Size of the block storage (`min: 20, max: 500, multipleOf: 10`)

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -23,6 +23,6 @@ resource "oneandone_ssh_key" "sshkey" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the storage
 * `description` - (Optional) Description for the ssh key
+* `name` - (Required) The name of the storage
 * `public_key` - (Optional) Public key to import. If not given, new SSH key pair will be created and the private key is returned in the response


### PR DESCRIPTION
Made the changes required in the [PR 14](https://github.com/terraform-providers/terraform-provider-oneandone/pull/14) comments:

Alphabetized the argument list in the block storage and ssh key docs.
Updated name and name_updated in the private network test.
Updated the delete ssh key method in the vendor folder oneandone-cloudserver sdk to the latest version.