### PR TITLE
Fixed WaitUntilDeleted failure

### DIFF
--- a/oneandone/resource_oneandone_monitoring_policy.go
+++ b/oneandone/resource_oneandone_monitoring_policy.go
@@ -537,6 +537,8 @@ func resourceOneandOneMonitoringPolicyDelete(d *schema.ResourceData, meta interf
 		return err
 	}
 
+	mp.Id = d.Id()
+
 	err = config.API.WaitUntilDeleted(mp)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixed WaitUntilDeleted failure caused by API no longer returning the MP object in the DELETE response by assigning Id value to monitoring policy before calling WaitUntilDeleted function.